### PR TITLE
fix: define portname in service

### DIFF
--- a/kubernetes/patroni_k8s.yaml
+++ b/kubernetes/patroni_k8s.yaml
@@ -108,6 +108,7 @@ spec:
   ports:
   - port: 5432
     targetPort: 5432
+    name: postgresql
 
 ---
 apiVersion: v1


### PR DESCRIPTION
If there is no portname defined, the endpoint won't be attached to the service. The portname in this case is "postgresql"